### PR TITLE
chore(release): bump version to 1.1.1, tiny bump, massive vibes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kittycad"
-version = "1.1.0"
+version = "1.1.1"
 description = "A client library for accessing KittyCAD"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "kittycad"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
- Update pyproject to 1.1.1 for patch release
- Sync uv.lock to revision 3 and kittycad 1.1.1, no code changes