### PR TITLE
feat(ws): typed wrappers from OpenAPI, because vibes are not types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the KittyCAD Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.2
+
+### Changed - WebSocket message typing
+
+- WebSocket wrapper classes now use request/response models from the OpenAPI spec:
+  - `ml_copilot_ws` sends `MlCopilotClientMessage` and yields/returns `MlCopilotServerMessage`.
+  - `modeling_commands_ws` continues to use `WebSocketRequest`/`WebSocketResponse` per spec.
+  - Endpoints without explicit schemas (e.g. `/ws/executor/term`) now default to `Dict[str, Any]`.
+
+### Fixed
+
+- WebSocket wrapper URLs now correctly interpolate path params and append query params (e.g. `ml_reasoning_ws(id=...)`).
+
+### Migration
+
+- If you previously typed your WebSocket code against `WebSocketRequest`/`WebSocketResponse` for ML copilot streams, update to the spec types:
+  - `ws.send(MlCopilotClientMessage(...))`
+  - `msg: MlCopilotServerMessage = ws.recv()`
+  - `for msg in ws: ...` (now yields `MlCopilotServerMessage`)
+
 ## v1.1.0
 
 ### Added - Enhanced Pydantic Models & Developer Experience 🎨
@@ -40,13 +60,14 @@ new_user = User.from_dict({"id": "456", "name": "Jane"})
 **Enhanced Code Generation Tests**: Added comprehensive test suite for code generation utilities:
 
 - **Acronym handling verification**: Tests ensure proper conversion of camelCase to snake_case
-- **Regression prevention**: Automated tests prevent future acronym handling regressions  
+- **Regression prevention**: Automated tests prevent future acronym handling regressions
 - **Integration with pytest**: Tests are discoverable and run with the main test suite
 - **Coverage verification**: Tests cover edge cases and common acronym patterns
 
 ### Technical Improvements
 
 **BaseModel Configuration**:
+
 ```python
 model_config = ConfigDict(
     protected_namespaces=(),     # Avoid namespace warnings
@@ -56,12 +77,14 @@ model_config = ConfigDict(
 )
 ```
 
-**Updated Code Generation**: 
+**Updated Code Generation**:
+
 - Templates now use `KittyCadBaseModel` instead of direct Pydantic `BaseModel`
 - Removed duplicate `ConfigDict` declarations from generated models
 - Added base model import to generated `__init__.py` files
 
 **Test Infrastructure**:
+
 - New test directory: `generate/tests/` for code generation utilities
 - Pytest-compatible test structure with proper parametrization
 - Tests verify both current behavior and improvements
@@ -96,6 +119,7 @@ except KittyCADTimeoutError as e:
 - **`KittyCADServerError`**: Enhanced 5xx errors with request context
 
 **Rich Debugging Context**: Exception attributes now include:
+
 - `request_method` and `request_url` for all HTTP-related errors
 - `original_error` for network errors to access underlying HTTPX exceptions
 - `timeout_seconds` for timeout errors
@@ -239,7 +263,7 @@ with open("/tmp/file.bin", "wb") as f:
 **Resource Management and Safety**: The SDK follows Python best practices for resource management:
 
 - **Only closes files it opens**: User-provided file objects are never closed by the SDK
-- **Automatic cleanup**: Context managers and proper resource cleanup for all operations  
+- **Automatic cleanup**: Context managers and proper resource cleanup for all operations
 - **Memory efficiency**: Streaming support prevents loading large files entirely into memory
 - **Error handling**: Comprehensive exception handling with detailed context
 
@@ -334,17 +358,17 @@ except FileNotFoundError:
 ### Developer Benefits
 
 1. **Better Debugging**: Readable model representations show key fields automatically
-2. **Easier Serialization**: Built-in methods for JSON/dict conversion with sensible defaults  
-3. **Cleaner Module Structure**: More intuitive import paths for OAuth2 and other acronym-heavy models
-4. **Enhanced Validation**: Stricter Pydantic settings catch more errors at development time
-5. **Future-Proof**: Test coverage ensures acronym handling improvements don't regress
-6. **Uniform Error Handling**: All errors use the same exception types with consistent attributes
-7. **Rich Error Context**: Comprehensive debugging information in all exception types
-8. **Predictable Error Behavior**: No more raw HTTPX exceptions surfacing to user code
-9. **Intuitive File Operations**: File handling feels as natural as OpenAI, Stripe, or Boto3 SDKs
-10. **Memory Efficient**: Streaming support handles files of any size without memory issues
-11. **Progress Visibility**: Built-in progress tracking for better user experience
-12. **Resource Safety**: Automatic resource management following Python best practices
+1. **Easier Serialization**: Built-in methods for JSON/dict conversion with sensible defaults
+1. **Cleaner Module Structure**: More intuitive import paths for OAuth2 and other acronym-heavy models
+1. **Enhanced Validation**: Stricter Pydantic settings catch more errors at development time
+1. **Future-Proof**: Test coverage ensures acronym handling improvements don't regress
+1. **Uniform Error Handling**: All errors use the same exception types with consistent attributes
+1. **Rich Error Context**: Comprehensive debugging information in all exception types
+1. **Predictable Error Behavior**: No more raw HTTPX exceptions surfacing to user code
+1. **Intuitive File Operations**: File handling feels as natural as OpenAI, Stripe, or Boto3 SDKs
+1. **Memory Efficient**: Streaming support handles files of any size without memory issues
+1. **Progress Visibility**: Built-in progress tracking for better user experience
+1. **Resource Safety**: Automatic resource management following Python best practices
 
 ## v1.0.0
 
@@ -434,6 +458,7 @@ asyncio.run(main())
 #### Paginated Endpoints
 
 The following endpoints now support automatic pagination:
+
 - **API Calls**: `list_api_calls()`, `org_list_api_calls()`, `user_list_api_calls()`
 - **ML**: `list_ml_prompts()`, `list_conversations_for_user()`, `list_text_to_cad_models_for_user()`
 - **Organizations**: `list_org_members()`, `get_org_shortlinks()`, `list_orgs()`
@@ -695,25 +720,3 @@ Example exception message:
 - **Easier Debugging**: No need to dig into Error objects
 - **Cleaner Code**: No error checking boilerplate needed
 - **Better IDE Support**: Improved autocomplete and type checking
-
-______________________________________________________________________
-
-## Previous Versions
-
-For changes prior to this version, see the git history or individual release notes.
-## Unreleased
-
-### Changed - WebSocket message typing
-- WebSocket wrapper classes now use request/response models from the OpenAPI spec:
-  - `ml_copilot_ws` sends `MlCopilotClientMessage` and yields/returns `MlCopilotServerMessage`.
-  - `modeling_commands_ws` continues to use `WebSocketRequest`/`WebSocketResponse` per spec.
-  - Endpoints without explicit schemas (e.g. `/ws/executor/term`) now default to `Dict[str, Any]`.
-
-### Fixed
-- WebSocket wrapper URLs now correctly interpolate path params and append query params (e.g. `ml_reasoning_ws(id=...)`).
-
-### Migration
-- If you previously typed your WebSocket code against `WebSocketRequest`/`WebSocketResponse` for ML copilot streams, update to the spec types:
-  - `ws.send(MlCopilotClientMessage(...))`
-  - `msg: MlCopilotServerMessage = ws.recv()`
-  - `for msg in ws: ...` (now yields `MlCopilotServerMessage`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -701,3 +701,19 @@ ______________________________________________________________________
 ## Previous Versions
 
 For changes prior to this version, see the git history or individual release notes.
+## Unreleased
+
+### Changed - WebSocket message typing
+- WebSocket wrapper classes now use request/response models from the OpenAPI spec:
+  - `ml_copilot_ws` sends `MlCopilotClientMessage` and yields/returns `MlCopilotServerMessage`.
+  - `modeling_commands_ws` continues to use `WebSocketRequest`/`WebSocketResponse` per spec.
+  - Endpoints without explicit schemas (e.g. `/ws/executor/term`) now default to `Dict[str, Any]`.
+
+### Fixed
+- WebSocket wrapper URLs now correctly interpolate path params and append query params (e.g. `ml_reasoning_ws(id=...)`).
+
+### Migration
+- If you previously typed your WebSocket code against `WebSocketRequest`/`WebSocketResponse` for ML copilot streams, update to the spec types:
+  - `ws.send(MlCopilotClientMessage(...))`
+  - `msg: MlCopilotServerMessage = ws.recv()`
+  - `for msg in ws: ...` (now yields `MlCopilotServerMessage`)

--- a/generate/templates/__init__.py.jinja2
+++ b/generate/templates/__init__.py.jinja2
@@ -30,7 +30,7 @@ from .exceptions import (
 )
 
 {% if has_websockets %}
-# Import WebSocket request/response models
+# Import WebSocket-related models that may be referenced by endpoints
 from .models.web_socket_request import WebSocketRequest
 from .models.web_socket_response import WebSocketResponse
 from .models.post_effect_type import PostEffectType
@@ -93,11 +93,28 @@ class WebSocket{{ func_name|to_pascal_case }}:
 
     ws: ClientConnectionSync
 
-    def __init__(self, *args, client: Client, **kwargs):
+    def __init__(self{{ func_info.websocket_params if func_info.websocket_params else '' }}, *, client: Client):
         # Inline WebSocket connection logic
-        url = (client.base_url + "{{ func_info.path }}").replace("http://", "ws://").replace("https://", "wss://")
+        {% set path_args = func_info.ws_args|selectattr("in_url")|list %}
+        url = ("{}" + "{{ func_info.path }}").format(client.base_url{% for arg in path_args %}, {{ arg.name }}={{ arg.name }}{% endfor %})
+        {% for arg in func_info.ws_args %}
+        {% if arg.in_query %}
+        if {{ arg.name }} is not None:
+            {% if "bool" in arg.type %}
+            if "?" in url:
+                url = url + "&{{ arg.name }}=" + str({{ arg.name }}).lower()
+            else:
+                url = url + "?{{ arg.name }}=" + str({{ arg.name }}).lower()
+            {% else %}
+            if "?" in url:
+                url = url + "&{{ arg.name }}=" + str({{ arg.name }})
+            else:
+                url = url + "?{{ arg.name }}=" + str({{ arg.name }})
+            {% endif %}
+        {% endif %}
+        {% endfor %}
         headers = client.get_headers()
-        self.ws = ws_connect(url, additional_headers=headers, close_timeout=120, max_size=None)
+        self.ws = ws_connect(url.replace("http", "ws"), additional_headers=headers, close_timeout=120, max_size=None)
 
     def __enter__(self):
         return self
@@ -115,20 +132,36 @@ class WebSocket{{ func_name|to_pascal_case }}:
         ConnectionClosedError exception after a protocol error or a network failure.
         """
         for message in self.ws:
-            yield WebSocketResponse(**json.loads(message))
+            {% if func_info.ws_response_is_dict %}
+            yield json.loads(message)
+            {% else %}
+            yield {{ func_info.ws_response_type }}.model_validate_json(message)
+            {% endif %}
 
-    def send(self, data: WebSocketRequest):
+    def send(self, data: {{ func_info.ws_request_type }}):
         """Send data to the websocket."""
+        {% if func_info.ws_request_is_dict %}
+        self.ws.send(json.dumps(data))
+        {% else %}
         self.ws.send(json.dumps(data.model_dump()))
+        {% endif %}
 
-    def send_binary(self, data: WebSocketRequest):
+    def send_binary(self, data: {{ func_info.ws_request_type }}):
         """Send data as bson to the websocket."""
+        {% if func_info.ws_request_is_dict %}
+        self.ws.send(bson.encode(data))
+        {% else %}
         self.ws.send(bson.encode(data.model_dump()))
+        {% endif %}
 
-    def recv(self) -> WebSocketResponse:
+    def recv(self) -> {{ func_info.ws_response_type }}:
         """Receive data from the websocket."""
         message = self.ws.recv(timeout=60)
-        return WebSocketResponse(**json.loads(message))
+        {% if func_info.ws_response_is_dict %}
+        return json.loads(message)
+        {% else %}
+        return {{ func_info.ws_response_type }}.model_validate_json(message)
+        {% endif %}
 
     def close(self):
         """Close the websocket."""

--- a/kittycad/__init__.py
+++ b/kittycad/__init__.py
@@ -158,7 +158,7 @@ from .models.user_results_page import UserResultsPage
 from .models.uuid import Uuid
 from .models.verification_token_response import VerificationTokenResponse
 
-# Import WebSocket request/response models
+# Import WebSocket-related models that may be referenced by endpoints
 from .models.web_socket_request import WebSocketRequest
 from .models.web_socket_response import WebSocketResponse
 from .models.zoo_product_subscriptions import ZooProductSubscriptions
@@ -693,7 +693,7 @@ class MlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -809,7 +809,7 @@ class MlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -1088,7 +1088,7 @@ class MlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -1321,7 +1321,7 @@ class AsyncMlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -1437,7 +1437,7 @@ class AsyncMlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -1716,7 +1716,7 @@ class AsyncMlAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -1966,7 +1966,7 @@ class ApiCallsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -2087,7 +2087,7 @@ class ApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -2230,7 +2230,7 @@ class ApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -2346,7 +2346,7 @@ class ApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -2467,7 +2467,7 @@ class ApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -2598,7 +2598,7 @@ class AsyncApiCallsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -2719,7 +2719,7 @@ class AsyncApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -2864,7 +2864,7 @@ class AsyncApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -2982,7 +2982,7 @@ class AsyncApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -3105,7 +3105,7 @@ class AsyncApiCallsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -5382,7 +5382,7 @@ class OrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -5749,7 +5749,7 @@ class OrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -5836,7 +5836,7 @@ class OrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -6122,7 +6122,7 @@ class AsyncOrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -6489,7 +6489,7 @@ class AsyncOrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -6576,7 +6576,7 @@ class AsyncOrgsAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -8450,7 +8450,7 @@ class ServiceAccountsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -8637,7 +8637,7 @@ class AsyncServiceAccountsAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -10130,7 +10130,7 @@ class UsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -10293,7 +10293,7 @@ class UsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -10380,7 +10380,7 @@ class UsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -10869,7 +10869,7 @@ class AsyncUsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -11032,7 +11032,7 @@ class AsyncUsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -11119,7 +11119,7 @@ class AsyncUsersAPI:
                 print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -11350,7 +11350,7 @@ class ApiTokensAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import SyncPageIterator
 
@@ -11531,7 +11531,7 @@ class AsyncApiTokensAPI:
                         print(item)
         """
 
-        from typing import Dict
+        from typing import Any, Dict
 
         from kittycad.pagination import AsyncPageIterator
 
@@ -11845,16 +11845,17 @@ class WebSocketMlCopilotWs:
 
     ws: ClientConnectionSync
 
-    def __init__(self, *args, client: Client, **kwargs):
+    def __init__(self, *, client: Client):
         # Inline WebSocket connection logic
-        url = (
-            (client.base_url + "/ws/ml/copilot")
-            .replace("http://", "ws://")
-            .replace("https://", "wss://")
-        )
+
+        url = ("{}" + "/ws/ml/copilot").format(client.base_url)
+
         headers = client.get_headers()
         self.ws = ws_connect(
-            url, additional_headers=headers, close_timeout=120, max_size=None
+            url.replace("http", "ws"),
+            additional_headers=headers,
+            close_timeout=120,
+            max_size=None,
         )
 
     def __enter__(self):
@@ -11873,20 +11874,23 @@ class WebSocketMlCopilotWs:
         ConnectionClosedError exception after a protocol error or a network failure.
         """
         for message in self.ws:
-            yield WebSocketResponse(**json.loads(message))
+            yield MlCopilotServerMessage.model_validate_json(message)
 
-    def send(self, data: WebSocketRequest):
+    def send(self, data: MlCopilotClientMessage):
         """Send data to the websocket."""
+
         self.ws.send(json.dumps(data.model_dump()))
 
-    def send_binary(self, data: WebSocketRequest):
+    def send_binary(self, data: MlCopilotClientMessage):
         """Send data as bson to the websocket."""
+
         self.ws.send(bson.encode(data.model_dump()))
 
-    def recv(self) -> WebSocketResponse:
+    def recv(self) -> MlCopilotServerMessage:
         """Receive data from the websocket."""
         message = self.ws.recv(timeout=60)
-        return WebSocketResponse(**json.loads(message))
+
+        return MlCopilotServerMessage.model_validate_json(message)
 
     def close(self):
         """Close the websocket."""
@@ -11898,16 +11902,17 @@ class WebSocketMlReasoningWs:
 
     ws: ClientConnectionSync
 
-    def __init__(self, *args, client: Client, **kwargs):
+    def __init__(self, id: str, *, client: Client):
         # Inline WebSocket connection logic
-        url = (
-            (client.base_url + "/ws/ml/reasoning/{id}")
-            .replace("http://", "ws://")
-            .replace("https://", "wss://")
-        )
+
+        url = ("{}" + "/ws/ml/reasoning/{id}").format(client.base_url, id=id)
+
         headers = client.get_headers()
         self.ws = ws_connect(
-            url, additional_headers=headers, close_timeout=120, max_size=None
+            url.replace("http", "ws"),
+            additional_headers=headers,
+            close_timeout=120,
+            max_size=None,
         )
 
     def __enter__(self):
@@ -11926,20 +11931,23 @@ class WebSocketMlReasoningWs:
         ConnectionClosedError exception after a protocol error or a network failure.
         """
         for message in self.ws:
-            yield WebSocketResponse(**json.loads(message))
+            yield MlCopilotServerMessage.model_validate_json(message)
 
-    def send(self, data: WebSocketRequest):
+    def send(self, data: MlCopilotClientMessage):
         """Send data to the websocket."""
+
         self.ws.send(json.dumps(data.model_dump()))
 
-    def send_binary(self, data: WebSocketRequest):
+    def send_binary(self, data: MlCopilotClientMessage):
         """Send data as bson to the websocket."""
+
         self.ws.send(bson.encode(data.model_dump()))
 
-    def recv(self) -> WebSocketResponse:
+    def recv(self) -> MlCopilotServerMessage:
         """Receive data from the websocket."""
         message = self.ws.recv(timeout=60)
-        return WebSocketResponse(**json.loads(message))
+
+        return MlCopilotServerMessage.model_validate_json(message)
 
     def close(self):
         """Close the websocket."""
@@ -11951,16 +11959,17 @@ class WebSocketCreateExecutorTerm:
 
     ws: ClientConnectionSync
 
-    def __init__(self, *args, client: Client, **kwargs):
+    def __init__(self, *, client: Client):
         # Inline WebSocket connection logic
-        url = (
-            (client.base_url + "/ws/executor/term")
-            .replace("http://", "ws://")
-            .replace("https://", "wss://")
-        )
+
+        url = ("{}" + "/ws/executor/term").format(client.base_url)
+
         headers = client.get_headers()
         self.ws = ws_connect(
-            url, additional_headers=headers, close_timeout=120, max_size=None
+            url.replace("http", "ws"),
+            additional_headers=headers,
+            close_timeout=120,
+            max_size=None,
         )
 
     def __enter__(self):
@@ -11979,20 +11988,23 @@ class WebSocketCreateExecutorTerm:
         ConnectionClosedError exception after a protocol error or a network failure.
         """
         for message in self.ws:
-            yield WebSocketResponse(**json.loads(message))
+            yield json.loads(message)
 
-    def send(self, data: WebSocketRequest):
+    def send(self, data: Dict[str, Any]):
         """Send data to the websocket."""
-        self.ws.send(json.dumps(data.model_dump()))
 
-    def send_binary(self, data: WebSocketRequest):
+        self.ws.send(json.dumps(data))
+
+    def send_binary(self, data: Dict[str, Any]):
         """Send data as bson to the websocket."""
-        self.ws.send(bson.encode(data.model_dump()))
 
-    def recv(self) -> WebSocketResponse:
+        self.ws.send(bson.encode(data))
+
+    def recv(self) -> Dict[str, Any]:
         """Receive data from the websocket."""
         message = self.ws.recv(timeout=60)
-        return WebSocketResponse(**json.loads(message))
+
+        return json.loads(message)
 
     def close(self):
         """Close the websocket."""
@@ -12004,16 +12016,91 @@ class WebSocketModelingCommandsWs:
 
     ws: ClientConnectionSync
 
-    def __init__(self, *args, client: Client, **kwargs):
+    def __init__(
+        self,
+        api_call_id: Optional[str] = None,
+        fps: Optional[int] = None,
+        pool: Optional[str] = None,
+        post_effect: Optional[PostEffectType] = None,
+        replay: Optional[str] = None,
+        show_grid: Optional[bool] = None,
+        unlocked_framerate: Optional[bool] = None,
+        video_res_height: Optional[int] = None,
+        video_res_width: Optional[int] = None,
+        webrtc: Optional[bool] = None,
+        *,
+        client: Client,
+    ):
         # Inline WebSocket connection logic
-        url = (
-            (client.base_url + "/ws/modeling/commands")
-            .replace("http://", "ws://")
-            .replace("https://", "wss://")
-        )
+
+        url = ("{}" + "/ws/modeling/commands").format(client.base_url)
+
+        if api_call_id is not None:
+            if "?" in url:
+                url = url + "&api_call_id=" + str(api_call_id)
+            else:
+                url = url + "?api_call_id=" + str(api_call_id)
+
+        if fps is not None:
+            if "?" in url:
+                url = url + "&fps=" + str(fps)
+            else:
+                url = url + "?fps=" + str(fps)
+
+        if pool is not None:
+            if "?" in url:
+                url = url + "&pool=" + str(pool)
+            else:
+                url = url + "?pool=" + str(pool)
+
+        if post_effect is not None:
+            if "?" in url:
+                url = url + "&post_effect=" + str(post_effect)
+            else:
+                url = url + "?post_effect=" + str(post_effect)
+
+        if replay is not None:
+            if "?" in url:
+                url = url + "&replay=" + str(replay)
+            else:
+                url = url + "?replay=" + str(replay)
+
+        if show_grid is not None:
+            if "?" in url:
+                url = url + "&show_grid=" + str(show_grid).lower()
+            else:
+                url = url + "?show_grid=" + str(show_grid).lower()
+
+        if unlocked_framerate is not None:
+            if "?" in url:
+                url = url + "&unlocked_framerate=" + str(unlocked_framerate).lower()
+            else:
+                url = url + "?unlocked_framerate=" + str(unlocked_framerate).lower()
+
+        if video_res_height is not None:
+            if "?" in url:
+                url = url + "&video_res_height=" + str(video_res_height)
+            else:
+                url = url + "?video_res_height=" + str(video_res_height)
+
+        if video_res_width is not None:
+            if "?" in url:
+                url = url + "&video_res_width=" + str(video_res_width)
+            else:
+                url = url + "?video_res_width=" + str(video_res_width)
+
+        if webrtc is not None:
+            if "?" in url:
+                url = url + "&webrtc=" + str(webrtc).lower()
+            else:
+                url = url + "?webrtc=" + str(webrtc).lower()
+
         headers = client.get_headers()
         self.ws = ws_connect(
-            url, additional_headers=headers, close_timeout=120, max_size=None
+            url.replace("http", "ws"),
+            additional_headers=headers,
+            close_timeout=120,
+            max_size=None,
         )
 
     def __enter__(self):
@@ -12032,20 +12119,23 @@ class WebSocketModelingCommandsWs:
         ConnectionClosedError exception after a protocol error or a network failure.
         """
         for message in self.ws:
-            yield WebSocketResponse(**json.loads(message))
+            yield WebSocketResponse.model_validate_json(message)
 
     def send(self, data: WebSocketRequest):
         """Send data to the websocket."""
+
         self.ws.send(json.dumps(data.model_dump()))
 
     def send_binary(self, data: WebSocketRequest):
         """Send data as bson to the websocket."""
+
         self.ws.send(bson.encode(data.model_dump()))
 
     def recv(self) -> WebSocketResponse:
         """Receive data from the websocket."""
         message = self.ws.recv(timeout=60)
-        return WebSocketResponse(**json.loads(message))
+
+        return WebSocketResponse.model_validate_json(message)
 
     def close(self):
         """Close the websocket."""

--- a/kittycad/client.py
+++ b/kittycad/client.py
@@ -21,7 +21,10 @@ class Client:
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""
-        return {"Authorization": f"Bearer {self.token}", **self.headers}
+        headers = {**self.headers}
+        if getattr(self, "token", None):
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def with_headers(self, headers: Dict[str, str]) -> "Client":
         """Get a new client matching this one with additional headers"""
@@ -84,7 +87,10 @@ class AsyncClient:
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""
-        return {"Authorization": f"Bearer {self.token}", **self.headers}
+        headers = {**self.headers}
+        if getattr(self, "token", None):
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def with_headers(self, headers: Dict[str, str]) -> "AsyncClient":
         """Get a new client matching this one with additional headers"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kittycad"
-version = "1.1.1"
+version = "1.1.2"
 description = "A client library for accessing KittyCAD"
 authors = []
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "kittycad"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -448,7 +448,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.1,<2.0.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.2,<1.0.0" },
     { name = "phonenumbers", specifier = ">=9.0.11" },
-    { name = "prance", marker = "extra == 'dev'", specifier = ">=23.6.21,<24.0.0" },
+    { name = "prance", marker = "extra == 'dev'", specifier = ">=23.6.21,<26.0.0" },
     { name = "pydantic", specifier = ">=2.9.1,<3.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.1.0,<3.0.0" },
     { name = "pyenchant", marker = "extra == 'docs'", specifier = ">=3.2.2,<4.0.0" },
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.7,<1.0.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.1.2,<8.0.0" },
     { name = "sphinx-autoapi", marker = "extra == 'docs'", specifier = ">=3.6.0,<4.0.0" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.3.0,<3.0.0" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.3.0,<4.0.0" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2,<1.0.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=3.0.2,<4.0.0" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'docs'", specifier = ">=8.0.0,<9.0.0" },


### PR DESCRIPTION
- WebSocket wrappers now use spec models; ML copilot uses MlCopilotClientMessage and MlCopilotServerMessage, endpoints without schemas fall back to Dict[str, Any]
- URLs in wrappers interpolate path params and append query params
- Generator emits wrappers for all WS endpoints, client only sends Authorization when token, version bump to 1.1.2